### PR TITLE
feat(tui): support enhanced keyboard protocols

### DIFF
--- a/packages/tui/src/input/actions.ts
+++ b/packages/tui/src/input/actions.ts
@@ -262,7 +262,13 @@ export class Actions extends Emitter<ActionEvents> {
   }
 
   dispatchKey(routed: RoutedKey, opts: { node?: boolean; global?: boolean } = {}): boolean {
-    const actions = (this.#keymap.get(canonical(routed.pattern)) ?? [])
+    if (routed.eventType === "release") return true
+
+    const patterns = [routed.pattern]
+    if (routed.base !== undefined) patterns.push(canonical({ ...routed, name: routed.base }))
+    const actions = [
+      ...new Set(patterns.flatMap((pattern) => this.#keymap.get(canonical(pattern)) ?? [])),
+    ]
       .map((id) => this.get(id))
       .filter((a) => filterAction(a))
       .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0))

--- a/packages/tui/src/input/decoder.ts
+++ b/packages/tui/src/input/decoder.ts
@@ -1,4 +1,4 @@
-import type { KeyEvent } from "./keys.ts"
+import type { KeyEvent, KeyEventType } from "./keys.ts"
 
 /**
  * Decoder — bytes (as a string, after the caller UTF-8 decodes them) in,
@@ -219,8 +219,18 @@ const TILDE_NAMES: Partial<Record<string, string>> = {
 
 const SS3_NAMES: Partial<Record<string, string>> = { P: "f1", Q: "f2", R: "f3", S: "f4" }
 
+/** A CSI primary/secondary Device Attributes reply (`CSI ? … c` / `CSI > … c`). */
+export function isDeviceAttributesResponse(params: string, final: string): boolean {
+  return final === "c" && /^[?>]\d+(?:;\d+)*$/.test(params)
+}
+
+/** A Kitty keyboard-protocol flags reply (`CSI ? <flags> u`). */
+export function isKittyFlagsResponse(params: string, final: string): boolean {
+  return final === "u" && /^\?\d+$/.test(params)
+}
+
 function isTerminalCsiResponse(params: string, final: string): boolean {
-  return final === "c" && (params.startsWith("?") || params.startsWith(">"))
+  return isDeviceAttributesResponse(params, final) || isKittyFlagsResponse(params, final)
 }
 
 function handleCsi(params: string, final: string, out: InputEvent[]): void {
@@ -233,22 +243,121 @@ function handleCsi(params: string, final: string, out: InputEvent[]): void {
 
   const arrow = ARROW_NAMES[final]
   if (arrow !== undefined) {
-    // Form is either `A` (no params) or `1;<mod>A` (modified).
-    const mod = parts.length === 2 ? Number.parseInt(parts[1], 10) : 1
-    out.push(key({ name: arrow, ...modBits(mod) }))
+    // Form is either `A` (no params) or `1;<mod>:<event>A`.
+    const { eventType, mod } = csiModifiers(parts[1])
+    out.push(key({ name: arrow, ...modBits(mod), ...(eventType ? { eventType } : {}) }))
     return
   }
 
   if (final === "~") {
+    if (parts[0] === "27" && parts.length === 3) {
+      pushCsiKey(Number.parseInt(parts[2] ?? "", 10), Number.parseInt(parts[1] ?? "", 10), out)
+      return
+    }
+
     const code = parts[0] ?? ""
     const name = TILDE_NAMES[code]
     if (name === undefined) return
-    const mod = parts.length === 2 ? Number.parseInt(parts[1], 10) : 1
-    out.push(key({ name, ...modBits(mod) }))
+    const { eventType, mod } = csiModifiers(parts[1])
+    out.push(key({ name, ...modBits(mod), ...(eventType ? { eventType } : {}) }))
+    return
+  }
+
+  if (final === "u") {
+    handleCsiU(params, out)
     return
   }
 
   // Unrecognized CSI — drop. (Cursor-position responses, etc.)
+}
+
+function csiModifiers(part: string | undefined): { eventType?: KeyEventType; mod: number } {
+  if (part === undefined) return { mod: 1 }
+  const [rawMod, rawEventType] = part.split(":", 2)
+  const mod = Number.parseInt(rawMod, 10)
+  const eventType = eventTypeFromDigit(rawEventType)
+  return eventType ? { eventType, mod } : { mod }
+}
+
+/** Kitty event-type sub-parameter: 1 = press (the default, usually omitted),
+ *  2 = repeat, 3 = release. */
+function eventTypeFromDigit(digit: string | undefined): KeyEventType | undefined {
+  if (digit === "1") return "press"
+  if (digit === "2") return "repeat"
+  if (digit === "3") return "release"
+  return undefined
+}
+
+function handleCsiU(params: string, out: InputEvent[]): void {
+  const match = params.match(/^(\d+)(?::(\d*))?(?::(\d+))?(?:;(\d+))?(?::([123]))?$/)
+  if (!match) return
+
+  const code = Number.parseInt(match[1], 10)
+  const mod = match[4] ? Number.parseInt(match[4], 10) : 1
+  const shifted = match[2] ? Number.parseInt(match[2], 10) : undefined
+  const base = match[3] ? Number.parseInt(match[3], 10) : undefined
+  pushCsiKey(code, mod, out, { base, eventType: eventTypeFromDigit(match[5]), shifted })
+}
+
+function pushCsiKey(
+  code: number,
+  mod: number,
+  out: InputEvent[],
+  opts: { base?: number; eventType?: KeyEventType; shifted?: number } = {}
+): void {
+  const name = CSI_U_NAMES[code] ?? nameFromCodePoint(code)
+  if (name === undefined) return
+
+  const mods = modBits(mod)
+  const event: Partial<KeyEvent> & { name: string } = { name, ...mods }
+  const base = opts.base !== undefined ? codePointToString(opts.base) : undefined
+  if (base !== undefined) event.base = base
+  if (opts.eventType !== undefined) event.eventType = opts.eventType
+  if (opts.eventType !== "release" && !mods.alt && !mods.ctrl && !mods.meta && name.length === 1) {
+    const shifted = opts.shifted !== undefined ? codePointToString(opts.shifted) : undefined
+    event.text = shifted ?? name
+  }
+  out.push(key(event))
+}
+
+// Unicode private-use area (U+E000..U+F8FF). The Kitty keyboard protocol
+// encodes functional keys (keypad, media, extra modifiers) as code points in
+// this block; the ones we model live in CSI_U_NAMES. Any other PUA code is a
+// key we don't name — it must be dropped, never rendered as a printable char.
+const PUA_START = 57_344
+const PUA_END = 63_743
+
+/** Convert a Unicode code point to a string, or `undefined` if it isn't a
+ *  usable printable scalar value (control char, surrogate, or out of range). */
+function codePointToString(cp: number): string | undefined {
+  if (!Number.isSafeInteger(cp) || cp < 32 || cp > 1_114_111) return undefined
+  if (cp >= 55_296 && cp <= 57_343) return undefined // lone surrogate (U+D800..U+DFFF)
+  return String.fromCodePoint(cp)
+}
+
+/** Like {@link codePointToString}, but also drops unnamed Kitty functional
+ *  keys so they never surface as private-use-area glyphs. */
+function nameFromCodePoint(code: number): string | undefined {
+  if (code >= PUA_START && code <= PUA_END) return undefined
+  return codePointToString(code)
+}
+
+const CSI_U_NAMES: Partial<Record<number, string>> = {
+  127: "backspace",
+  13: "enter",
+  27: "esc",
+  57_414: "enter",
+  57_417: "left",
+  57_418: "right",
+  57_419: "up",
+  57_420: "down",
+  57_421: "pageup",
+  57_422: "pagedown",
+  57_423: "home",
+  57_424: "end",
+  57_425: "insert",
+  57_426: "delete",
+  9: "tab",
 }
 
 function handleMouse(params: string, final: string, out: InputEvent[]): void {
@@ -371,6 +480,8 @@ function key(partial: Partial<KeyEvent> & { name: string }): InputEvent {
       meta: partial.meta ?? false,
       name: partial.name,
       shift: partial.shift ?? false,
+      ...(partial.base !== undefined ? { base: partial.base } : {}),
+      ...(partial.eventType !== undefined ? { eventType: partial.eventType } : {}),
       ...(partial.text !== undefined ? { text: partial.text } : {}),
     },
     type: "key",

--- a/packages/tui/src/input/keys.ts
+++ b/packages/tui/src/input/keys.ts
@@ -24,9 +24,15 @@
  *   - `meta-`  (a.k.a. super / cmd)
  */
 
+export type KeyEventType = "press" | "repeat" | "release"
+
 export interface KeyEvent {
   /** Canonical key name — raw character or one of the named constants above. */
   name: string
+  /** Base-layout key reported by the Kitty keyboard protocol, when available. */
+  base?: string
+  /** Key state reported by the Kitty keyboard protocol. */
+  eventType?: KeyEventType
   /**
    * The literal text the keystroke would insert, when that makes sense.
    * For printable chars this is the char itself; for Enter, Tab, etc. it's
@@ -183,7 +189,24 @@ export function keyMatches(ev: KeyEvent, pattern: string | readonly string[]): b
     return false
   }
   const p = parsePattern(pattern as string)
-  const e = normalizeKey(ev)
+  if (parsedMatches(normalizeKey(ev), p)) return true
+  // Fall back to the Kitty base-layout key so bindings written for the
+  // standard (Latin) layout still fire on alternate layouts — e.g. a
+  // Cyrillic `с` reports `base: "c"`, matching a `ctrl-c` binding.
+  if (ev.base !== undefined && ev.base !== ev.name) {
+    const base = normalizeKey({
+      alt: ev.alt,
+      ctrl: ev.ctrl,
+      meta: ev.meta,
+      name: ev.base,
+      shift: ev.shift,
+    })
+    if (parsedMatches(base, p)) return true
+  }
+  return false
+}
+
+function parsedMatches(e: ParsedPattern, p: ParsedPattern): boolean {
   return (
     e.name === p.name &&
     e.ctrl === p.ctrl &&

--- a/packages/tui/src/input/router.ts
+++ b/packages/tui/src/input/router.ts
@@ -1,7 +1,7 @@
 import type { Node } from "../core/node.ts"
 import type { Actions } from "./actions.ts"
 import type { InputEvent, MouseEvent, TerminalResponseEvent } from "./decoder.ts"
-import type { KeyEvent, KeyPattern } from "./keys.ts"
+import type { KeyEvent, KeyEventType, KeyPattern } from "./keys.ts"
 
 import { Emitter } from "@zaly/shared"
 import { Logger } from "@zaly/shared/logger"
@@ -24,6 +24,8 @@ export type KeymapEntry = string | KeyHandler
  */
 export interface RoutedKey {
   name: string
+  base?: string
+  eventType?: KeyEventType
   text?: string
   ctrl: boolean
   alt: boolean
@@ -226,6 +228,8 @@ function makeRoutedKey(ev: KeyEvent): RoutedKey {
     },
     stopped: false,
   }
+  if (ev.base !== undefined) r.base = ev.base
+  if (ev.eventType !== undefined) r.eventType = ev.eventType
   if (ev.text !== undefined) r.text = ev.text
   return r
 }

--- a/packages/tui/src/renderer/renderer.ts
+++ b/packages/tui/src/renderer/renderer.ts
@@ -120,6 +120,9 @@ export class Renderer extends Emitter<RenderEvents> {
 
   readonly #decoder = new Decoder()
   readonly #stdin: TerminalReader & { setEncoding?: (enc: string) => void }
+  readonly #onUnhandledRejection = (reason: unknown): void => {
+    this.logger.child("unhandledRejection").error("Unhandled Rejection:", reason)
+  }
 
   #theme = signal<Theme | undefined>(undefined)
 
@@ -214,6 +217,9 @@ export class Renderer extends Emitter<RenderEvents> {
       if (event.kind === "scroll") void this.stream.scroll(event.deltaY)
       else this.selection.mouse(event)
     })
+    this.input.on("term-response", ({ event }) =>
+      this.terminal.handleKeyboardProtocolResponse(event)
+    )
     this.input.on("key", ({ event }) => {
       if (event.name === "esc") this.selection.clear()
     })
@@ -363,9 +369,7 @@ export class Renderer extends Emitter<RenderEvents> {
     // setInterval(() => {
     //   console.log(this.stats.get())
     // }, 5000)
-    process.on("unhandledRejection", (reason) =>
-      this.logger.child("unhandledRejection").error("Unhandled Rejection:", reason)
-    )
+    process.on("unhandledRejection", this.#onUnhandledRejection)
   }
 
   stop(): void {
@@ -377,6 +381,7 @@ export class Renderer extends Emitter<RenderEvents> {
     this.#running = false
     this.#stdin.off("data", this.#onData)
     this.#stdin.pause?.()
+    process.off("unhandledRejection", this.#onUnhandledRejection)
     if (this.#escTimer !== undefined) {
       clearTimeout(this.#escTimer)
       this.#escTimer = undefined

--- a/packages/tui/src/renderer/terminal.ts
+++ b/packages/tui/src/renderer/terminal.ts
@@ -7,7 +7,10 @@
  * escape sequences through the helpers exposed below.
  */
 
+import type { TerminalResponseEvent } from "../input/decoder.ts"
+
 import { inspect } from "node:util"
+import { isDeviceAttributesResponse, isKittyFlagsResponse } from "../input/decoder.ts"
 
 export interface TerminalWriter {
   readonly columns: number
@@ -73,6 +76,9 @@ export class Terminal {
   #progress: ProgressState = { type: "inactive" }
   #progressInterval: ReturnType<typeof setInterval> | undefined
   #prevRawMode: boolean | undefined
+  #kittyKeyboard = false
+  #kittyKeyboardPushed = false
+  #modifyOtherKeys = false
   #resizeListeners = new Set<ResizeListener>()
   #signalCleanup: (() => void) | undefined
   #onResize = (): void => {
@@ -131,6 +137,14 @@ export class Terminal {
     )
   }
 
+  get kittyKeyboard(): boolean {
+    return this.#kittyKeyboard
+  }
+
+  get modifyOtherKeys(): boolean {
+    return this.#modifyOtherKeys
+  }
+
   // ---------- lifecycle ----------
 
   /**
@@ -152,6 +166,15 @@ export class Terminal {
     // terminal tell us when our window gains/loses focus so we can
     // update cursor visibility, pause animations, etc.
     this.write(`${CSI}?25l${CSI}?7l${CSI}?2004h${CSI}?1004h`)
+    // Enhanced keyboard reporting. Push Kitty flags, query them, then request
+    // *secondary* Device Attributes as a fence: every terminal answers it, so
+    // if no Kitty flags reply (`CSI ? u`) arrives before it, Kitty keyboard is
+    // unsupported and we fall back to xterm modifyOtherKeys. Secondary DA
+    // (not primary `CSI c`) keeps us off the primary-DA channel that the
+    // image-detection queries fence on, so the two can't consume each other's
+    // replies.
+    this.#kittyKeyboardPushed = true
+    this.write(`${CSI}>7u${CSI}?u${CSI}>c`)
     if (this.#mouse) this.write(`${CSI}?1002h${CSI}?1006h${CSI}?1007h`)
     this.#writeProgress()
     // Scroll region set to [1, scrollBottom]. Terminals default to the
@@ -199,6 +222,46 @@ export class Terminal {
     }
   }
 
+  handleKeyboardProtocolResponse(event: TerminalResponseEvent): boolean {
+    // Ignore responses that arrive after teardown — writing enable/disable
+    // sequences to an already-restored terminal would leak modes into the
+    // user's shell.
+    if (!this.#started || event.kind !== "csi") return false
+
+    if (isKittyFlagsResponse(event.params, event.final)) {
+      const flags = Number.parseInt(event.params.slice(1), 10)
+      if (flags > 0) {
+        this.#kittyKeyboard = true
+        this.#disableModifyOtherKeys()
+      } else {
+        this.#enableModifyOtherKeys()
+      }
+      return true
+    }
+
+    // Only the secondary-DA reply (`CSI > … c`) is our fence. Primary-DA
+    // replies (`CSI ? … c`) belong to the image-detection queries — leave
+    // them for that subsystem instead of consuming them here.
+    if (isDeviceAttributesResponse(event.params, event.final) && event.params.startsWith(">")) {
+      if (!this.#kittyKeyboard) this.#enableModifyOtherKeys()
+      return true
+    }
+
+    return false
+  }
+
+  #enableModifyOtherKeys(): void {
+    if (this.#modifyOtherKeys) return
+    this.write(`${CSI}>4;2m`)
+    this.#modifyOtherKeys = true
+  }
+
+  #disableModifyOtherKeys(): void {
+    if (!this.#modifyOtherKeys) return
+    this.write(`${CSI}>4;0m`)
+    this.#modifyOtherKeys = false
+  }
+
   deleteImages(opts: { data?: boolean } = {}): void {
     if (!this.#started) return
     // Remove all Kitty images. KGP doesn't support selective deletion, so
@@ -222,6 +285,10 @@ export class Terminal {
       // Wipe the visible viewport — covers both leftover footer rows
       // and any half-painted stream rows from an in-flight render that
       // was killed mid-paint (crash path). Scrollback is unaffected.
+      if (this.#kittyKeyboardPushed) this.write(`${CSI}<u`)
+      this.#kittyKeyboardPushed = false
+      this.#kittyKeyboard = false
+      this.#disableModifyOtherKeys()
       this.write(
         `${CSI}?1007l${CSI}?1006l${CSI}?1002l${CSI}?1000l${CSI}?1004l${CSI}?2004l${CSI}?7h${CSI}?25h`
       )

--- a/packages/tui/test/input/decoder.test.ts
+++ b/packages/tui/test/input/decoder.test.ts
@@ -104,6 +104,62 @@ describe("Decoder — CSI sequences", () => {
   test("F5 via ESC [ 15 ~", () => {
     expect(keys(new Decoder(), "\x1b[15~")).toEqual([{ mods: "", name: "f5" }])
   })
+
+  test("shift+enter via CSI-u", () => {
+    expect(keys(new Decoder(), "\x1b[13;2u")).toEqual([{ mods: "s", name: "enter" }])
+  })
+
+  test("ctrl+c via CSI-u", () => {
+    expect(keys(new Decoder(), "\x1b[99;5u")).toEqual([{ mods: "c", name: "c" }])
+  })
+
+  test("xterm modifyOtherKeys encodes shift+enter", () => {
+    expect(keys(new Decoder(), "\x1b[27;2;13~")).toEqual([{ mods: "s", name: "enter" }])
+  })
+
+  test("Kitty arrows preserve event type", () => {
+    expect(new Decoder().feed("\x1b[1;1:3C")).toEqual([
+      {
+        event: {
+          alt: false,
+          ctrl: false,
+          eventType: "release",
+          meta: false,
+          name: "right",
+          shift: false,
+        },
+        type: "key",
+      },
+    ])
+  })
+
+  test("Kitty CSI-u preserves alternate keys and event type", () => {
+    expect(new Decoder().feed("\x1b[99:67:99;6:2u")).toEqual([
+      {
+        event: {
+          alt: false,
+          base: "c",
+          ctrl: true,
+          eventType: "repeat",
+          meta: false,
+          name: "c",
+          shift: true,
+        },
+        type: "key",
+      },
+    ])
+  })
+
+  test("named Kitty functional key (numpad enter)", () => {
+    // 57414 = KP_ENTER — mapped in CSI_U_NAMES.
+    expect(keys(new Decoder(), "\x1b[57414u")).toEqual([{ mods: "", name: "enter" }])
+  })
+
+  test("drops unmodeled Kitty functional keys instead of emitting PUA glyphs", () => {
+    // 57404 (KP_5) sits in the private-use area with no name mapping; it must
+    // not surface as a printable char with garbage text.
+    expect(new Decoder().feed("\x1b[57404u")).toEqual([])
+  })
 })
 
 describe("Decoder — SS3 function keys", () => {
@@ -224,6 +280,14 @@ describe("Decoder — terminal responses", () => {
         sequence: "\x1b[>1;4000;0c",
         type: "term-response",
       },
+    ])
+  })
+
+  test("holds a split Kitty keyboard protocol response", () => {
+    const d = new Decoder()
+    expect(d.feed("\x1b[?7")).toEqual([])
+    expect(d.feed("u")).toEqual([
+      { final: "u", kind: "csi", params: "?7", sequence: "\x1b[?7u", type: "term-response" },
     ])
   })
 

--- a/packages/tui/test/input/keys.test.ts
+++ b/packages/tui/test/input/keys.test.ts
@@ -74,6 +74,17 @@ describe("keyMatches", () => {
   test("rejects unrecognised modifier-looking prefixes", () => {
     expect(() => keyMatches(k("foo-bar"), "foo-bar")).toThrow(/unknown modifier/)
   })
+
+  test("matches the Kitty base-layout key on alternate layouts", () => {
+    // Cyrillic `с` on a ctrl press reports the layout char as `name` and the
+    // physical (Latin) key as `base` — a `ctrl-c` binding should still fire.
+    const ev = k("с", { base: "c", ctrl: true })
+    expect(keyMatches(ev, "ctrl-c")).toBe(true)
+    // The literal layout char still matches its own name.
+    expect(keyMatches(k("с", { base: "c" }), "с")).toBe(true)
+    // Base only matches when the modifiers line up.
+    expect(keyMatches(k("с", { base: "c" }), "ctrl-c")).toBe(false)
+  })
 })
 
 describe("canonical", () => {

--- a/packages/tui/test/input/router.test.ts
+++ b/packages/tui/test/input/router.test.ts
@@ -213,6 +213,22 @@ describe("InputRouter — keymap → action dispatch", () => {
     expect(fired).toBe(1)
   })
 
+  test("Kitty base-layout keys match actions", () => {
+    const { actions, router } = setup()
+    let fired = 0
+    actions.register({ "global.quit": { fn: () => fired++, keys: ["ctrl-c"] } })
+    router.dispatch({ event: makeKey("с", { base: "c", ctrl: true }), type: "key" })
+    expect(fired).toBe(1)
+  })
+
+  test("ignores Kitty key releases", () => {
+    const { actions, router } = setup()
+    let fired = 0
+    actions.register({ "input.cursorRight": { fn: () => fired++, keys: ["right"] } })
+    router.dispatch({ event: makeKey("right", { eventType: "release" }), type: "key" })
+    expect(fired).toBe(0)
+  })
+
   test("dispatch walks the focus chain for node.actions[id]", () => {
     const { actions, mount, router } = setup()
     const parent = mount(box({}))

--- a/packages/tui/test/renderer/mock.ts
+++ b/packages/tui/test/renderer/mock.ts
@@ -3,6 +3,7 @@ import type { SurfaceType } from "../../src/renderer/index.ts"
 import type { TerminalReader, TerminalWriter } from "../../src/renderer/terminal.ts"
 
 import { Logger } from "@zaly/shared/logger"
+import { afterEach } from "vitest"
 import { Actions } from "../../src/input/actions.ts"
 import { TerminalQueries } from "../../src/input/queries.ts"
 import { InputRouter } from "../../src/input/router.ts"
@@ -83,4 +84,23 @@ export class MockReader implements TerminalReader {
   readonly isTTY = false
   on(): void {}
   off(): void {}
+}
+
+/**
+ * Register an `afterEach` that stops every tracked stoppable and clears the
+ * set. Call once at a test file's top level, then pass anything with a
+ * `stop()` (a `Terminal`, a `Renderer`, …) through the returned `track` fn so
+ * started terminals don't leak their progress interval / resize listeners
+ * across tests. Returns the value for inline use.
+ */
+export function autoStop(): <T extends { stop: () => void }>(v: T) => T {
+  const items = new Set<{ stop: () => void }>()
+  afterEach(() => {
+    for (const item of items) item.stop()
+    items.clear()
+  })
+  return (v) => {
+    items.add(v)
+    return v
+  }
 }

--- a/packages/tui/test/renderer/renderer.test.ts
+++ b/packages/tui/test/renderer/renderer.test.ts
@@ -15,6 +15,17 @@ async function renderer() {
   })
 }
 
+describe("renderer lifecycle", () => {
+  test("removes its unhandled rejection listener when stopped", async () => {
+    const r = await renderer()
+    const before = process.listenerCount("unhandledRejection")
+    r.start()
+    expect(process.listenerCount("unhandledRejection")).toBe(before + 1)
+    r.stop()
+    expect(process.listenerCount("unhandledRejection")).toBe(before)
+  })
+})
+
 describe("renderer.getNode — lookup by id", () => {
   test("finds a node tagged with id anywhere in the UI tree", async () => {
     const r = await renderer()

--- a/packages/tui/test/renderer/stream.test.ts
+++ b/packages/tui/test/renderer/stream.test.ts
@@ -3,13 +3,16 @@ import { describe, expect, test } from "vitest"
 import { createAsync, memo } from "../../src/core/reactive.ts"
 import { Renderer } from "../../src/renderer/renderer.ts"
 import { text } from "../../src/widgets/text.ts"
-import { MockReader, MockWriter } from "./mock.ts"
+import { autoStop, MockReader, MockWriter } from "./mock.ts"
+
+const track = autoStop()
 
 function mount(cols = 20, rows = 10) {
   const stdout = new MockWriter(cols, rows)
   const renderer = new Renderer({ hookSignals: false, stdin: new MockReader(), stdout })
   const { stream, terminal } = renderer
   terminal.start()
+  track(terminal)
   stdout.clear()
   // Tests exercise Stream in isolation (no Renderer present). Self-
   // schedule on `"dirty"` so `stream.add(...)` still eventually renders

--- a/packages/tui/test/renderer/terminal.test.ts
+++ b/packages/tui/test/renderer/terminal.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "vitest"
 import { Terminal } from "../../src/renderer/terminal.ts"
-import { MockReader, MockWriter } from "./mock.ts"
+import { autoStop, MockReader, MockWriter } from "./mock.ts"
+
+const track = autoStop()
 
 function makeTerminal(cols = 80, rows = 24, reserveBottom = 0) {
   const stdout = new MockWriter(cols, rows)
   const stdin = new MockReader()
-  const terminal = new Terminal({ hookSignals: false, reserveBottom, stdin, stdout })
+  const terminal = track(new Terminal({ hookSignals: false, reserveBottom, stdin, stdout }))
   return { stdout, terminal }
 }
 
@@ -31,13 +33,112 @@ describe("Terminal.start / stop", () => {
     // Hide cursor + DECAWM off.
     expect(stdout.all).toContain("\x1b[?25l")
     expect(stdout.all).toContain("\x1b[?7l")
+    expect(stdout.all).toContain("\x1b[>7u\x1b[?u\x1b[>c")
     // DECSTBM bounds: [1, 17].
     expect(stdout.all).toContain("\x1b[1;17r")
     terminal.stop()
     // On stop: DECSTBM reset, DECAWM + cursor back on.
     expect(stdout.all).toContain("\x1b[r")
+    expect(stdout.all).toContain("\x1b[<u")
     expect(stdout.all).toContain("\x1b[?7h")
     expect(stdout.all).toContain("\x1b[?25h")
+  })
+
+  test("enables Kitty keyboard reporting after a positive response", () => {
+    const { stdout, terminal } = makeTerminal()
+    terminal.start()
+    expect(
+      terminal.handleKeyboardProtocolResponse({
+        final: "u",
+        kind: "csi",
+        params: "?7",
+        sequence: "\x1b[?7u",
+        type: "term-response",
+      })
+    ).toBe(true)
+    expect(terminal.kittyKeyboard).toBe(true)
+    expect(terminal.modifyOtherKeys).toBe(false)
+    terminal.stop()
+    expect(stdout.all).toContain("\x1b[<u")
+  })
+
+  test("falls back to xterm modifyOtherKeys when Kitty is unavailable", () => {
+    const { stdout, terminal } = makeTerminal()
+    terminal.start()
+    expect(
+      terminal.handleKeyboardProtocolResponse({
+        final: "c",
+        kind: "csi",
+        params: ">41;348;0",
+        sequence: "\x1b[>41;348;0c",
+        type: "term-response",
+      })
+    ).toBe(true)
+    expect(terminal.kittyKeyboard).toBe(false)
+    expect(terminal.modifyOtherKeys).toBe(true)
+    expect(stdout.all).toContain("\x1b[>4;2m")
+    terminal.stop()
+    expect(stdout.all).toContain("\x1b[>4;0m")
+  })
+
+  test("leaves primary Device Attributes replies for the image-detection queries", () => {
+    // Primary DA (`CSI ? … c`) is the image-detection fence; the keyboard
+    // handler must not consume it or enable a fallback from it.
+    const { terminal } = makeTerminal()
+    terminal.start()
+    expect(
+      terminal.handleKeyboardProtocolResponse({
+        final: "c",
+        kind: "csi",
+        params: "?62;4;52",
+        sequence: "\x1b[?62;4;52c",
+        type: "term-response",
+      })
+    ).toBe(false)
+    expect(terminal.modifyOtherKeys).toBe(false)
+    terminal.stop()
+  })
+
+  test("switches from the fallback when a delayed Kitty response arrives", () => {
+    const { stdout, terminal } = makeTerminal()
+    terminal.start()
+    terminal.handleKeyboardProtocolResponse({
+      final: "c",
+      kind: "csi",
+      params: ">41;348;0",
+      sequence: "\x1b[>41;348;0c",
+      type: "term-response",
+    })
+    expect(terminal.modifyOtherKeys).toBe(true)
+
+    terminal.handleKeyboardProtocolResponse({
+      final: "u",
+      kind: "csi",
+      params: "?7",
+      sequence: "\x1b[?7u",
+      type: "term-response",
+    })
+    expect(terminal.kittyKeyboard).toBe(true)
+    expect(terminal.modifyOtherKeys).toBe(false)
+    expect(stdout.all).toContain("\x1b[>4;0m")
+    terminal.stop()
+  })
+
+  test("ignores malformed keyboard protocol responses", () => {
+    const { terminal } = makeTerminal()
+    terminal.start()
+    expect(
+      terminal.handleKeyboardProtocolResponse({
+        final: "u",
+        kind: "csi",
+        params: "?7;1",
+        sequence: "\x1b[?7;1u",
+        type: "term-response",
+      })
+    ).toBe(false)
+    expect(terminal.kittyKeyboard).toBe(false)
+    expect(terminal.modifyOtherKeys).toBe(false)
+    terminal.stop()
   })
 
   test("no DECSTBM emitted when reserveBottom is 0", () => {

--- a/packages/tui/test/renderer/ui.test.ts
+++ b/packages/tui/test/renderer/ui.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "vitest"
 import { Renderer } from "../../src/renderer/renderer.ts"
 import { text } from "../../src/widgets/text.ts"
-import { MockReader, MockWriter } from "./mock.ts"
+import { autoStop, MockReader, MockWriter } from "./mock.ts"
+
+const track = autoStop()
 
 function mount(cols = 20, rows = 10) {
   const stdout = new MockWriter(cols, rows)
   const renderer = new Renderer({ hookSignals: false, stdin: new MockReader(), stdout })
   const { terminal, ui } = renderer
   terminal.start()
+  track(terminal)
   stdout.clear()
   return { stdout, terminal, ui }
 }


### PR DESCRIPTION
## Summary

- negotiate Kitty keyboard protocol reporting and validate the terminal response before enabling it
- fall back to xterm `modifyOtherKeys` when Kitty reporting is unavailable
- decode CSI-u key metadata, including base-layout keys, shifted text, event types, keypad Enter, navigation keys, and xterm fallback sequences
- prevent key-release events from dispatching actions, while preserving repeats
- restore keyboard modes during terminal teardown and clean up renderer event listeners in tests and runtime

## Testing

- `bun z test`