### PR TITLE
fix(tui): align input cursor with wide characters

### DIFF
--- a/packages/tui/src/widgets/input.ts
+++ b/packages/tui/src/widgets/input.ts
@@ -562,15 +562,12 @@ function isWhitespace(ch: string | undefined): boolean {
 }
 
 function posToLineCol(value: string, cursor: number): { line: number; col: number } {
-  let line = 0
-  let col = 0
-  for (let i = 0; i < cursor; i++) {
-    if (value[i] === "\n") {
-      line++
-      col = 0
-    } else col++
+  const prefix = value.slice(0, cursor)
+  const lineStart = prefix.lastIndexOf("\n") + 1
+  return {
+    line: prefix.split("\n").length - 1,
+    col: stringWidth(prefix.slice(lineStart)),
   }
-  return { col, line }
 }
 
 function lineColToPos(value: string, line: number, col: number): number {
@@ -578,7 +575,16 @@ function lineColToPos(value: string, line: number, col: number): number {
   const clampLine = Math.max(0, Math.min(line, lines.length - 1))
   let abs = 0
   for (let i = 0; i < clampLine; i++) abs += lines[i].length + 1
-  return abs + Math.min(col, lines[clampLine].length)
+
+  let cells = 0
+  let offset = 0
+  for (const ch of lines[clampLine]) {
+    const width = stringWidth(ch)
+    if (cells + width > col) break
+    cells += width
+    offset += ch.length
+  }
+  return abs + offset
 }
 
 function lineEndPos(value: string, cursor: number): number {

--- a/packages/tui/test/nodes/input.test.ts
+++ b/packages/tui/test/nodes/input.test.ts
@@ -45,6 +45,12 @@ function cursorCtx(width = 40) {
   return ret
 }
 
+function markedCursorCtx(width = 40) {
+  const ret = ctx(width)
+  ;(ret.style as { inverse: (s: string) => string }).inverse = (s: string) => `<${s}>`
+  return ret
+}
+
 describe("Input — initial state", () => {
   test("defaults to empty value and cursor=0", () => {
     const n = input()
@@ -123,6 +129,12 @@ describe("Input.actions — cursor motion", () => {
     expect(n.state.cursor).toBe(2)
   })
 
+  test("cursorUp preserves the visual column across a double-width character", () => {
+    const n = input({ cursor: 5, value: "가x\nabc" })
+    n.actions["input.cursorUp"]()
+    expect(n.state.cursor).toBe(1)
+  })
+
   test("cursorUp clamps to end of prev line when col exceeds it", () => {
     const n = input({ cursor: 9, value: "ab\nlonger" })
     n.actions["input.cursorUp"]()
@@ -139,6 +151,12 @@ describe("Input.actions — cursor motion", () => {
     const n = input({ cursor: 1, value: "abcd\nefgh" })
     n.actions["input.cursorDown"]()
     expect(n.state.cursor).toBe(6)
+  })
+
+  test("cursorDown preserves the visual column across a double-width character", () => {
+    const n = input({ cursor: 2, value: "abc\n가x" })
+    n.actions["input.cursorDown"]()
+    expect(n.state.cursor).toBe(5)
   })
 
   test("cursorDown on the last line is a no-op", () => {
@@ -506,6 +524,16 @@ describe("Input — render", () => {
     void n.emit("focus")
     const rows = await n.render(cursorCtx(40))
     expect(rows).toEqual(["asdasdaddd", "sdss", "█", "sss kkkdddd"])
+  })
+
+  test("renders the cursor after a double-width character", async () => {
+    const n = input({ cursor: 1, value: "가a" })
+    n.mount(mockMountCtx("ui"))
+    void n.emit("focus")
+
+    const rows = await n.render(markedCursorCtx(20))
+
+    expect(rows).toEqual(["가<a>"])
   })
 
   test("cursorLeft from the end of a multiline input visibly moves onto the last char", async () => {

--- a/packages/tui/test/terminal/resize.test.ts
+++ b/packages/tui/test/terminal/resize.test.ts
@@ -68,6 +68,28 @@ describe("Renderer — resize", () => {
     h.dispose()
   })
 
+  test("focused async-formatted input immediately paints a trailing double-width character", async () => {
+    const h = await makeHarness({ cols: 30, rows: 6 })
+    const field = input({ format: () => new Promise<string>(() => {}) })
+    h.renderer.ui.root.add(field)
+    h.renderer.input.focus(field)
+    h.renderer.input.dispatch({
+      event: {
+        alt: false,
+        ctrl: false,
+        meta: false,
+        name: "안",
+        shift: false,
+        text: "안",
+      },
+      type: "key",
+    })
+    await h.flush()
+
+    expect(h.viewport()[5]).toContain("안")
+    h.dispose()
+  })
+
   test("resize clears previously-painted rows above the new scroll region", async () => {
     // Shrink the viewport so rows that used to hold content fall
     // outside the new geometry. After resize, the new viewport must


### PR DESCRIPTION
## Summary

  Fix TUI input cursor/rendering behavior for wide glyphs such as Korean and CJK characters.

  - Compute input cursor columns using terminal cell width instead of JavaScript string length
  - Map visual columns back to string offsets for vertical cursor movement
  - Add regressions for wide-character cursor placement and Korean input rendering

  ## Verification

  - `bun x vitest run packages/tui/test/nodes/input.test.ts packages/tui/test/terminal/resize.test.ts`
  - `git diff --check`
  - `bun z build`
  - `./packages/cli/dist/zaly.mjs --help`

  ## Notes

  This fixes the cursor offset issue for committed wide characters. The remaining “one syllable delayed” behavior appears to depend on terminal IME preedit/commit
  timing: standard TTY input only receives text after the terminal commits it, so the app cannot render preedit text that has not been delivered yet.

---

### Before
https://github.com/user-attachments/assets/0fff00a6-e2a0-44c5-a540-c7afcbd9ba93

### After


https://github.com/user-attachments/assets/f96e9282-169a-4c2f-a2aa-24403df1312f

