### PR TITLE
fix(tui): preserve hyperlinks across wrapped URLs

### DIFF
--- a/packages/ai/src/auth/oauth/browser.ts
+++ b/packages/ai/src/auth/oauth/browser.ts
@@ -21,9 +21,8 @@ export async function browserLogin(opts: OAuthBrowserLogin): Promise<OAuthToken 
   await opts.notify?.({
     details: `Open [this URL](${u}) in your browser and complete login,
 or paste the authorization code / redirect URL here.
-\`\`\`
-${u}
-\`\`\``,
+
+[${u}](${u})`,
     title: `**${opts.name}** Login (browser)`,
   })
 

--- a/packages/ai/src/auth/oauth/device.ts
+++ b/packages/ai/src/auth/oauth/device.ts
@@ -14,9 +14,8 @@ export async function deviceCodeLogin(opts: OAuthDeviceLogin): Promise<OAuthToke
     void opts.browse?.(device.verificationUrl)
     await opts.notify?.({
       details: `Open [this URL](${device.verificationUrl}) in your browser, and enter code \`${device.userCode}\` to authorize ${opts.name}.
-\`\`\`
-${device.verificationUrl}
-\`\`\``,
+
+[${device.verificationUrl}](${device.verificationUrl})`,
       title: `**${opts.name}** Login (headless)`,
     })
   }

--- a/packages/shared/src/ansi.ts
+++ b/packages/shared/src/ansi.ts
@@ -83,19 +83,56 @@ export function sliceAnsi(s: string, start: number, end?: number): string {
   return apc + ret.replaceAll(KITTY_SENTINEL_RE, (sentinel) => clusters.get(sentinel) ?? sentinel)
 }
 
+const OSC8_RE = /\x1b\]8;[^;]*;([^\x07\x1b]*)(\x07|\x1b\\)/g
+const OSC8_MARKER = "\x1b]8;"
+const OSC8_SENTINEL_RE = /\x1b\[\?2026;(\d+)z/g
+
 /** Word- or char-wrap to `width` cells while preserving SGR state and
  *  APC escapes. Wraps line-by-line so APCs (zero-width, positional —
  *  e.g. kitty image placements) stay on their source line. A single
  *  global extract+prepend would collapse every APC onto row 0 of the
  *  output, and downstream `splitAnsi` would then re-prepend those to
- *  every row; the image placement would fire on every painted row. */
+ *  every row; the image placement would fire on every painted row.
+ *
+ *  OSC 8 escapes are replaced with zero-width CSI sentinels while wrapping,
+ *  then restored and reopened on every output row. Neither Bun.wrapAnsi nor
+ *  wrap-ansi handles OSC 8 correctly on its own. */
 export function wrapAnsi(s: string, width: number, opts?: WrapOpts): string {
   const char = opts?.mode === "char"
+  const wrapOpts = { hard: true, trim: false, wordWrap: !char } as const
   return s
     .split("\n")
     .map((line) => {
       const { apc, rest } = extractApc(line)
-      return apc + _wrapAnsi(rest, width, { hard: true, trim: false, wordWrap: !char })
+      if (!rest.includes(OSC8_MARKER)) return apc + _wrapAnsi(rest, width, wrapOpts)
+
+      const links: { close: string; open: boolean; sequence: string }[] = []
+      const protectedLine = rest.replace(OSC8_RE, (sequence, href: string, terminator: string) => {
+        const index = links.push({
+          close: `\x1b]8;;${terminator}`,
+          open: href !== "",
+          sequence,
+        }) - 1
+        return `\x1b[?2026;${index}z`
+      })
+      const wrapped = _wrapAnsi(protectedLine, width, wrapOpts)
+      let active: (typeof links)[number] | undefined
+      return (
+        apc +
+        wrapped
+          .split("\n")
+          .map((row) => {
+            let out = active?.sequence ?? ""
+            out += row.replace(OSC8_SENTINEL_RE, (_sentinel, rawIndex: string) => {
+              const link = links[Number(rawIndex)]
+              active = link.open ? link : undefined
+              return link.sequence
+            })
+            if (active) out += active.close
+            return out
+          })
+          .join("\n")
+      )
     })
     .join("\n")
 }

--- a/packages/shared/test/ansi.test.ts
+++ b/packages/shared/test/ansi.test.ts
@@ -34,6 +34,25 @@ describe("ANSI primitives", () => {
     )
   })
 
+  test("wrapAnsi preserves OSC 8 hyperlinks across wrapped rows", () => {
+    const url =
+      "https://example.com/docs?first=abcdefghijklmnopqrstuvwxyz&second=0123456789abcdefghijklmnopqrstuvwxyz&third=abcdefghijklmnop"
+    const linked = `\x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\`
+    const rows = wrapAnsi(`See ${linked} for details.`, 40).split("\n")
+    expect(rows.length).toBeGreaterThan(1)
+    expect(rows.every((row) => stringWidth(row) <= 40)).toBe(true)
+    expect(rows.filter((row) => row.includes(url)).length).toBeGreaterThan(1)
+    expect(rows.map((row) => stripAnsi(row)).join("")).toBe(`See ${url} for details.`)
+  })
+
+  test("wrapAnsi preserves a hyperlink's BEL terminator", () => {
+    const url = "https://example.com/abcdefghijklmnopqrstuvwxyz"
+    const linked = `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`
+    const rows = wrapAnsi(linked, 12).split("\n")
+    expect(rows.every((row) => row.includes(`\x1b]8;;${url}\x07`))).toBe(true)
+    expect(rows.every((row) => row.endsWith("\x1b]8;;\x07"))).toBe(true)
+  })
+
   test("hasAnsi detects SGR escapes only", () => {
     expect(hasAnsi("\x1b[31mred")).toBe(true)
     expect(hasAnsi("\x1b[2Kclear")).toBe(false)

--- a/packages/tui/src/markdown/callbacks.ts
+++ b/packages/tui/src/markdown/callbacks.ts
@@ -32,8 +32,9 @@ const alertRe = /^\s*\[!(NOTE|TIP|WARNING|IMPORTANT|CAUTION)\]\s*$/
  * a custom `Text` content function).
  * @internal
  */
-export function createCallbacks(ctx: MarkdownCtx): MdCallbacks {
+export function createCallbacks(ctx: MarkdownCtx, linkPrefix = crypto.randomUUID()): MdCallbacks {
   const s = ctx.style
+  let linkSeq = 0
 
   return {
     blockquote: (children) => {
@@ -76,7 +77,8 @@ export function createCallbacks(ctx: MarkdownCtx): MdCallbacks {
 
     html: (children) => children,
 
-    link: (children, { href }) => hyperlink(href, s.mdLink(children)),
+    link: (children, { href }) =>
+      hyperlink(href, s.mdLink(children), `${linkPrefix}-${++linkSeq}`),
 
     paragraph: (children) => `${children}\n\n`,
 

--- a/packages/tui/src/markdown/renderer.ts
+++ b/packages/tui/src/markdown/renderer.ts
@@ -15,6 +15,7 @@ export type MarkdownCtx = RenderCtx & {
 export class MarkdownRenderer {
   #render?: RenderMarkdown
   #images = new Map<string, Image>()
+  #linkPrefix = crypto.randomUUID()
   #parent?: Node
   #opts: MarkdownOptions
 
@@ -32,7 +33,7 @@ export class MarkdownRenderer {
       import("./image.ts"),
     ])
 
-    const callbacks = createCallbacks(ctx)
+    const callbacks = createCallbacks(ctx, this.#linkPrefix)
 
     // Image handling: the callback emits `<img id=N>` markers during
     // rendering; a post-processing resolver then renders the referenced

--- a/packages/tui/src/runtime/md.bun.ts
+++ b/packages/tui/src/runtime/md.bun.ts
@@ -19,7 +19,10 @@ export function renderMarkdown(input: string, callbacks: MdCallbacks, opts?: MdO
           ...callbacks,
           code: (text, meta) => callbacks.code!(text, decodeCodeMeta(meta)),
         }
-  return Bun.markdown.render(encoded, wrapped, opts)
+  return Bun.markdown.render(encoded, wrapped, {
+    ...opts,
+    autolinks: opts?.autolinks ?? true,
+  })
 }
 
 function decodeCodeMeta(meta: MdCodeBlockMeta | undefined): MdCodeBlockMeta | undefined {

--- a/packages/tui/src/style/ansi.ts
+++ b/packages/tui/src/style/ansi.ts
@@ -74,9 +74,10 @@ const colorCache = new Map<string, string | typeof notFound>()
  *
  * @internal
  */
-export function hyperlink(url: string, text: string): string {
+export function hyperlink(url: string, text: string, id?: string): string {
   if (url === "") return text
-  return `${OSC8}${url}${ST}${text}${OSC8}${ST}`
+  const open = id ? `\x1b]8;id=${id};` : OSC8
+  return `${open}${url}${ST}${text}${OSC8}${ST}`
 }
 
 export function ansiColor(color: AnsiColor, kind: "fg" | "bg"): string | undefined {

--- a/packages/tui/test/nodes/markdown.test.ts
+++ b/packages/tui/test/nodes/markdown.test.ts
@@ -1,4 +1,4 @@
-import { RESET } from "@zaly/shared/ansi"
+import { RESET, stripAnsi as stripControl } from "@zaly/shared/ansi"
 // oxlint-disable unicorn/no-await-expression-member
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest"
 import { renderMarkdown } from "#md"
@@ -99,9 +99,26 @@ describe("markdown — inline callbacks", () => {
   test("link wraps in mdLink + OSC 8 hyperlink", async () => {
     const open = expectedOpen("mdLink")
     const out = render("[click](https://example.com)")
-    expect(out).toContain("\x1b]8;;https://example.com\x1b\\")
+    expect(out).toMatch(/\x1b\]8;id=[^;]+-1;https:\/\/example\.com\x1b\\/)
     expect(out).toContain(`${open}click${RESET}`)
     expect(out).toContain("\x1b]8;;\x1b\\")
+  })
+
+  test("long bare URL stays clickable across soft wraps", async () => {
+    // Callbacks alone don't wrap; the markdown widget's layout does.
+    const { createRender } = await import("../../src/core/render.ts")
+    const url =
+      "https://example.com/docs?first=abcdefghijklmnopqrstuvwxyz&second=0123456789abcdefghijklmnopqrstuvwxyz&third=abcdefghijklmnop"
+    const rows = await createRender(() => markdown(`See ${url} for details.`), ctx(40))
+    const linkRows = rows.filter((r) => r.includes("\x1b]8;"))
+    expect(linkRows.length).toBeGreaterThan(1)
+    const ids = linkRows.map(
+      (row) => /\x1b\]8;id=([^;]+);/.exec(row)?.[1]
+    )
+    expect(ids.every(Boolean)).toBe(true)
+    expect(new Set(ids).size).toBe(1)
+    expect(linkRows.every((r) => r.includes(`;${url}\x1b\\`))).toBe(true)
+    expect(rows.map((r) => stripControl(r)).join("")).toBe(`See ${url} for details.`)
   })
 
   test("nested strong inside heading keeps heading style after inner reset", async () => {

--- a/packages/tui/test/style/ansi.test.ts
+++ b/packages/tui/test/style/ansi.test.ts
@@ -170,6 +170,12 @@ describe("hyperlink (OSC 8)", () => {
   test("empty URL: returns text unchanged (no-op)", () => {
     expect(hyperlink("", "text")).toBe("text")
   })
+
+  test("includes an optional hyperlink id", () => {
+    expect(hyperlink("https://example.com", "click", "link-1")).toBe(
+      "\x1b]8;id=link-1;https://example.com\x1b\\click\x1b]8;;\x1b\\"
+    )
+  })
 })
 
 describe("hasAnsi", () => {


### PR DESCRIPTION
## Summary

Fixes OSC 8 hyperlinks throughout the TUI, including long URLs that wrap across rows.

## Changes

- Preserve OSC 8 hyperlink state across ANSI-wrapped rows, including BEL-terminated links.
- Assign stable link IDs so full-screen redraws keep wrapped fragments in one logical hyperlink.
- Enable bare URL autolinking in the Bun Markdown renderer.
- Render browser and device OAuth URLs as Markdown links, preserving the blank separator before the URL.

## Validation

- `bun test packages/shared/test/ansi.test.ts packages/tui/test/style/ansi.test.ts packages/tui/test/nodes/markdown.test.ts`
- `bun run lint`