### PR TITLE
feat(tui): expand large paste markers on re-paste

### DIFF
--- a/packages/tui/src/widgets/input.ts
+++ b/packages/tui/src/widgets/input.ts
@@ -309,13 +309,19 @@ export class Input extends Node<InputState, InputEvents> {
     }
 
     const id = this.#staged.length + 1
+    // Marker shape: [prefix #id meta suffix]
+    //   prefix — attachment kind ("Pasted text", "Image", …)
+    //   meta   — size/name details (" +6 lines", " notes.txt")
+    //   suffix — interaction hint (" — Paste again to expand")
     let prefix = att.type[0].toUpperCase() + att.type.slice(1)
+    let meta = ""
     let suffix = ""
     if (att.type === "paste") {
       prefix = "Pasted text"
-      suffix = ` +${countLines(att.text)} lines`
-    } else if (!["image", "pdf"].includes(att.type)) suffix = ` ${basename(att.path)}`
-    const marker = `[${prefix} #${id}${suffix}]`
+      meta = ` +${countLines(att.text)} lines`
+      suffix = " — Paste again to expand"
+    } else if (!["image", "pdf"].includes(att.type)) meta = ` ${basename(att.path)}`
+    const marker = `[${prefix} #${id}${meta}${suffix}]`
     this.#staged.push({ ...att, id, marker })
     this.insert(marker)
 
@@ -323,6 +329,24 @@ export class Input extends Node<InputState, InputEvents> {
   }
 
   paste(text: string): void {
+    // Re-pasting content that is still staged as a collapsed marker expands
+    // that marker in place. Prefer the most recently staged match.
+    const value = this.state.value ?? ""
+    for (let i = this.#staged.length - 1; i >= 0; i--) {
+      const att = this.#staged[i]!
+      if (att.type !== "paste" || att.text !== text) continue
+      if (!value.includes(att.marker)) continue
+      const at = value.indexOf(att.marker)
+      this.#historyEdit()
+      this.#preferredCol = undefined
+      this.#staged.splice(i, 1)
+      this.state.set({
+        cursor: at + att.text.length,
+        value: value.slice(0, at) + att.text + value.slice(at + att.marker.length),
+      })
+      return
+    }
+
     if (
       countLines(text) > (this.state.pasteMaxLines ?? PASTE_MAX_LINES) ||
       stringWidth(text) > (this.state.pasteMaxChars ?? PASTE_MAX_CHARS)

--- a/packages/tui/test/nodes/input.test.ts
+++ b/packages/tui/test/nodes/input.test.ts
@@ -393,12 +393,84 @@ describe("Input — printable-char fallback", () => {
   })
 })
 
+/** Six lines — above the default `pasteMaxLines` threshold of 5. */
+const LARGE_PASTE = "a\nb\nc\nd\ne\nf"
+const LARGE_PASTE_2 = "x\ny\nz\nw\nv\nu"
+
 describe("Input — paste", () => {
   test("paste inserts the whole payload at the cursor", () => {
     const n = input({ cursor: 1, value: "ac" })
     void n.emit("paste", { paste: paste("BB") })
     expect(n.state.value).toBe("aBBc")
     expect(n.state.cursor).toBe(3)
+  })
+
+  test("large paste creates a marker with a paste-again hint", () => {
+    const n = input()
+    n.paste(LARGE_PASTE)
+    expect(n.state.value).toMatch(/^\[Pasted text #1 \+6 lines — Paste again to expand\]$/)
+  })
+
+  test("pasting the same large text again expands the marker", () => {
+    const n = input()
+    n.paste(LARGE_PASTE)
+    n.paste(LARGE_PASTE)
+    expect(n.state.value).toBe(LARGE_PASTE)
+    expect(n.state.cursor).toBe(LARGE_PASTE.length)
+  })
+
+  test("expansion preserves surrounding text and places the cursor after the expanded content", () => {
+    const n = input({ cursor: 3, value: "foo|bar" })
+    n.paste(LARGE_PASTE)
+    const marker = n.state.value ?? ""
+    expect(marker.startsWith("foo")).toBe(true)
+    expect(marker.endsWith("|bar")).toBe(true)
+    // Move cursor away so expansion must recompute position from the marker.
+    n.state.cursor = 0
+    n.paste(LARGE_PASTE)
+    expect(n.state.value).toBe(`foo${LARGE_PASTE}|bar`)
+    expect(n.state.cursor).toBe(`foo${LARGE_PASTE}`.length)
+  })
+
+  test("after expansion, consume returns the text once without duplication", () => {
+    const n = input()
+    n.paste(LARGE_PASTE)
+    n.paste(LARGE_PASTE)
+    const result = n.consume()
+    expect(result.value).toBe(LARGE_PASTE)
+    expect(result.attachments).toEqual([])
+  })
+
+  test("a second large paste with different text creates a separate marker", () => {
+    const n = input()
+    n.paste(LARGE_PASTE)
+    const first = n.state.value ?? ""
+    n.paste(LARGE_PASTE_2)
+    const value = n.state.value ?? ""
+    expect(value).toContain(first)
+    expect(value).toMatch(/\[Pasted text #2 \+6 lines — Paste again to expand\]/)
+    expect(value).not.toContain(LARGE_PASTE)
+    expect(value).not.toContain(LARGE_PASTE_2)
+  })
+
+  test("small pastes insert directly, including repeated small pastes", () => {
+    const n = input()
+    n.paste("hi")
+    n.paste("hi")
+    expect(n.state.value).toBe("hihi")
+    expect(n.state.cursor).toBe(4)
+  })
+
+  test("a marker removed by the user cannot be expanded by a later paste", () => {
+    const n = input()
+    n.paste(LARGE_PASTE)
+    const value = n.state.value ?? ""
+    n.state.cursor = value.length
+    n.actions["input.deleteCharBack"]()
+    expect(n.state.value).toBe("")
+    n.paste(LARGE_PASTE)
+    // Marker is gone, so this is a fresh large paste — still collapsed.
+    expect(n.state.value).toMatch(/^\[Pasted text #2 \+6 lines — Paste again to expand\]$/)
   })
 })
 


### PR DESCRIPTION
## Summary

Large pastes already collapse into a compact marker. This adds one interaction: pasting the **same content** again expands that marker back into editable text.

- Marker hint: `[Pasted text #1 +N lines — Paste again to expand]`
- Decision happens in `Input.paste(text)` (shared by bracketed paste and clipboard paste), so no key combination is hard-coded
- Different content still creates a new marker; small pastes still insert normally
- File/image attachments and paste thresholds are unchanged

## Tests

Unit coverage in `packages/tui/test/nodes/input.test.ts` for expand-on-re-paste, surrounding text/cursor, `consume()`, separate markers, small pastes, and deleted markers.